### PR TITLE
ci: upgrade playwright 1.57.0 → 1.60.0 (fix stuck Install Playwright Browsers)

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -27,7 +27,7 @@
     "@vitest/browser": "^4.1.6",
     "@vitest/browser-playwright": "^4.1.6",
     "msw": "^2.10.4",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "typescript": "^5.7.3",
     "vite": "^7.1.11",
     "vitest": "^4.1.6",

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -29,7 +29,7 @@
     "@vitest/browser": "^4.1.6",
     "@vitest/browser-playwright": "^4.1.6",
     "msw": "^2.10.4",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.0.0",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -25,7 +25,7 @@
     "@vitest/browser": "^4.1.6",
     "@vitest/browser-playwright": "^4.1.6",
     "msw": "^2.10.4",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "tailwindcss": "^4.0.0",
     "vite": "^7.1.11",
     "vitest": "^4.1.6",

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -64,7 +64,7 @@
     "@vitest/browser-playwright": "^4.1.6",
     "cssnano": "^7.0.7",
     "jsdom": "^26.1.0",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "resize-observer-polyfill": "^1.5.0",

--- a/packages/@uppy/golden-retriever/package.json
+++ b/packages/@uppy/golden-retriever/package.json
@@ -54,7 +54,7 @@
     "@uppy/xhr-upload": "workspace:^",
     "@vitest/browser": "^4.1.6",
     "@vitest/browser-playwright": "^4.1.6",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "typescript": "^5.8.3",
     "vitest": "^4.1.6"
   }

--- a/packages/@uppy/url/package.json
+++ b/packages/@uppy/url/package.json
@@ -58,7 +58,7 @@
     "@vitest/browser": "^4.1.6",
     "@vitest/browser-playwright": "^4.1.6",
     "cssnano": "^7.0.7",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",

--- a/packages/@uppy/xhr-upload/package.json
+++ b/packages/@uppy/xhr-upload/package.json
@@ -51,7 +51,7 @@
     "jsdom": "^26.1.0",
     "msw": "^2.10.4",
     "nock": "^13.1.0",
-    "playwright": "1.57.0",
+    "playwright": "1.60.0",
     "typescript": "^5.8.3",
     "vitest": "^4.1.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8754,7 +8754,7 @@ __metadata:
     jsdom: "npm:^26.1.0"
     lodash: "npm:^4.18.1"
     nanoid: "npm:^5.1.11"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     postcss: "npm:^8.5.6"
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
@@ -8852,7 +8852,7 @@ __metadata:
     "@vitest/browser": "npm:^4.1.6"
     "@vitest/browser-playwright": "npm:^4.1.6"
     lodash: "npm:^4.18.1"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     typescript: "npm:^5.8.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
@@ -9209,7 +9209,7 @@ __metadata:
     "@vitest/browser-playwright": "npm:^4.1.6"
     cssnano: "npm:^7.0.7"
     nanoid: "npm:^5.1.11"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     postcss: "npm:^8.5.6"
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
@@ -9310,7 +9310,7 @@ __metadata:
     jsdom: "npm:^26.1.0"
     msw: "npm:^2.10.4"
     nock: "npm:^13.1.0"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     typescript: "npm:^5.8.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
@@ -13078,7 +13078,7 @@ __metadata:
     "@vitest/browser": "npm:^4.1.6"
     "@vitest/browser-playwright": "npm:^4.1.6"
     msw: "npm:^2.10.4"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     tailwindcss: "npm:^4.0.9"
@@ -13136,7 +13136,7 @@ __metadata:
     "@vitest/browser": "npm:^4.1.6"
     "@vitest/browser-playwright": "npm:^4.1.6"
     msw: "npm:^2.10.4"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     svelte: "npm:^5.0.0"
     svelte-check: "npm:^4.0.0"
     tailwindcss: "npm:^4.0.0"
@@ -13182,7 +13182,7 @@ __metadata:
     "@vitest/browser": "npm:^4.1.6"
     "@vitest/browser-playwright": "npm:^4.1.6"
     msw: "npm:^2.10.4"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.60.0"
     tailwindcss: "npm:^4.0.0"
     vite: "npm:^7.1.11"
     vitest: "npm:^4.1.6"
@@ -18841,27 +18841,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.57.0":
-  version: 1.57.0
-  resolution: "playwright-core@npm:1.57.0"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/ec066602f0196f036006caee14a30d0a57533a76673bb9a0c609ef56e21decf018f0e8d402ba2fb18251393be6a1c9e193c83266f1670fe50838c5340e220de0
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:1.57.0":
-  version: 1.57.0
-  resolution: "playwright@npm:1.57.0"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.57.0"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/241559210f98ef11b6bd6413f2d29da7ef67c7865b72053192f0d164fab9e0d3bd47913b3351d5de6433a8aff2d8424d4b8bd668df420bf4dda7ae9fcd37b942
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fork-only CI test for the upstream stuck-CI issue (transloadit/uppy#6315).

The CI `Install Playwright Browsers` step (`playwright install --with-deps`) hangs for the full 6h job limit on ubuntu-latest with playwright 1.57.0 — on main and PRs alike, with no repo change to playwright/the command/ci.yml. Root cause: 1.57.0's `--with-deps` apt phase vs a newer ubuntu-latest runner image. This bumps playwright 1.57.0 → 1.60.0.

**Purpose of this PR:** run the real CI workflow on a GitHub runner to confirm the bump clears the hang before raising upstream. Not for merge.